### PR TITLE
fix(auth): remove JWT issuer/audience validation

### DIFF
--- a/src/constant.js
+++ b/src/constant.js
@@ -32,8 +32,6 @@ const {
   REDIS_SENTINEL_PORT = 26379,
   REDIS_MASTER_NAME = 'mymaster',
   BCRYPT_ROUNDS = '12',
-  JWT_ISSUER = 'hydre-auth',
-  JWT_AUDIENCE = 'hydre-services',
   ALLOWED_EMAILS = '',
 } = process.env
 
@@ -109,8 +107,6 @@ export const ENVIRONMENT = {
   REDIS_SENTINEL_PORT: +REDIS_SENTINEL_PORT,
   REDIS_MASTER_NAME,
   BCRYPT_ROUNDS: +BCRYPT_ROUNDS,
-  JWT_ISSUER,
-  JWT_AUDIENCE,
   ALLOWED_EMAILS: parse_allowed_emails(),
 }
 

--- a/src/resolvers/confirm_account.js
+++ b/src/resolvers/confirm_account.js
@@ -9,10 +9,7 @@ const public_key = await importSPKI(ENVIRONMENT.PUBLIC_KEY, 'ES512')
 
 const is_token_valid = async (token, valid_uuid) => {
   try {
-    const { payload } = await jwtVerify(token, public_key, {
-      issuer: ENVIRONMENT.JWT_ISSUER,
-      audience: ENVIRONMENT.JWT_AUDIENCE,
-    })
+    const { payload } = await jwtVerify(token, public_key)
 
     return payload.uuid === valid_uuid
   } catch {

--- a/src/resolvers/create_account_confirm_code.js
+++ b/src/resolvers/create_account_confirm_code.js
@@ -36,8 +36,6 @@ export default async ({ lang }, { redis, koa_context, force_logout }) => {
   const verification_code = await new SignJWT({ uuid: user.uuid })
     .setProtectedHeader({ alg: 'ES512' })
     .setIssuedAt()
-    .setIssuer(ENVIRONMENT.JWT_ISSUER)
-    .setAudience(ENVIRONMENT.JWT_AUDIENCE)
     .setExpirationTime(ENVIRONMENT.CONFIRM_ACCOUNT_TOKEN_EXPIRATION)
     .sign(private_key)
 

--- a/src/resolvers/create_user.js
+++ b/src/resolvers/create_user.js
@@ -35,8 +35,6 @@ export default async ({ mail, pwd, lang }, { redis }) => {
   const verification_code = await new SignJWT({ uuid: user_uuid })
     .setProtectedHeader({ alg: 'ES512' })
     .setIssuedAt()
-    .setIssuer(ENVIRONMENT.JWT_ISSUER)
-    .setAudience(ENVIRONMENT.JWT_AUDIENCE)
     .setExpirationTime(ENVIRONMENT.CONFIRM_ACCOUNT_TOKEN_EXPIRATION)
     .sign(private_key)
 

--- a/src/token.js
+++ b/src/token.js
@@ -10,8 +10,6 @@ const {
   COOKIE_PATH,
   COOKIE_SECURE,
   COOKIE_DOMAIN,
-  JWT_ISSUER,
-  JWT_AUDIENCE,
 } = ENVIRONMENT
 
 // Import PEM keys using jose's built-in functions
@@ -25,8 +23,6 @@ export default (koa_context) => ({
       if (!token) return {}
 
       const { payload } = await jwtVerify(token, public_key, {
-        issuer: JWT_ISSUER,
-        audience: JWT_AUDIENCE,
         ...(ignoreExpiration && { clockTolerance: Infinity }),
       })
       return payload
@@ -48,8 +44,6 @@ export default (koa_context) => ({
     const access_token = await new SignJWT(bearer)
       .setProtectedHeader({ alg: 'ES512' })
       .setIssuedAt()
-      .setIssuer(JWT_ISSUER)
-      .setAudience(JWT_AUDIENCE)
       .setExpirationTime(ACCESS_TOKEN_EXPIRATION)
       .sign(private_key)
 


### PR DESCRIPTION
## Summary

Removes JWT issuer and audience validation that was causing silent JWT verification failures.

## Root Cause

Empty environment variables (`JWT_ISSUER=""` and `JWT_AUDIENCE=""`) override default values in the code, causing JWT verification to fail silently when `jwtVerify` checks for empty string issuer/audience claims.

## Solution

Remove issuer/audience validation entirely - not needed for this authentication use case.

## Changes

- **src/constant.js**: Removed `JWT_ISSUER` and `JWT_AUDIENCE` environment variable definitions
- **src/token.js**: Removed `issuer` and `audience` parameters from `jwtVerify` and `SignJWT` calls
- **src/resolvers/confirm_account.js**: Removed `issuer` and `audience` from `jwtVerify`
- **src/resolvers/create_user.js**: Removed `issuer` and `audience` from `SignJWT`
- **src/resolvers/create_account_confirm_code.js**: Removed `issuer` and `audience` from `SignJWT`

## Test Plan

- [ ] JWT generation succeeds without issuer/audience claims
- [ ] JWT verification succeeds without issuer/audience validation
- [ ] Account creation flow works end-to-end
- [ ] Account confirmation flow works end-to-end
- [ ] Existing sessions continue to work

🤖 Generated with [Claude Code](https://claude.com/claude-code)