### PR TITLE
feat(schema): expose superadmin field on User type

### DIFF
--- a/src/resolvers/create_user.js
+++ b/src/resolvers/create_user.js
@@ -30,10 +30,6 @@ export default async ({ mail, pwd, lang }) => {
   const existing_user = await user_db.find_by_email(mail)
   if (existing_user) throw new GraphQLError(ERRORS.MAIL_USED)
 
-  // Check if this is the first user (make them superadmin)
-  const user_count = await user_db.count()
-  const is_first_user = user_count === 0
-
   // Create verification code
   const user_uuid = `User:${uuid4()}`
   const verification_code = await new SignJWT({ uuid: user_uuid })
@@ -48,7 +44,7 @@ export default async ({ mail, pwd, lang }) => {
     verification_code,
     hash: pwd ? await bcrypt.hash(pwd, ENVIRONMENT.BCRYPT_ROUNDS) : undefined,
     verified: !ENVIRONMENT.ENABLE_EMAIL, // Auto-verify when email is disabled
-    superadmin: is_first_user, // First user is superadmin
+    superadmin: false, // Superadmin is granted manually via DB
     last_reset_code_sent: 0,
     last_verification_code_sent: Date.now(),
     member_since: Date.now(),

--- a/src/schema.gql
+++ b/src/schema.gql
@@ -177,5 +177,6 @@ type User {
   mail: String!
   sessions: [Session!]!
   verified: Boolean!
+  superadmin: Boolean!
   member_since: String!
 }


### PR DESCRIPTION
## Summary
- Add `superadmin: Boolean!` to GraphQL User type for noxant-app to query
- Remove auto-superadmin for first user registration (superadmin is now manual DB grant only)

## Test plan
- [ ] Verify `{ me { superadmin } }` query works
- [ ] Verify new users get `superadmin: false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)